### PR TITLE
fixed .Hugo.Generator => hugo.Generator

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,7 @@
 <html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}">
 <head>
 <meta charset="utf-8">
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link href="//fonts.googleapis.com/css?family=Open+Sans:400,800" rel="stylesheet" type="text/css">
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,7 +2,7 @@
 <html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}">
 <head>
 <meta charset="utf-8">
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link href="//fonts.googleapis.com/css?family=Open+Sans:400,800" rel="stylesheet" type="text/css">
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">

--- a/layouts/taxonomy/category.html
+++ b/layouts/taxonomy/category.html
@@ -2,7 +2,7 @@
 <html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}">
   <head>
     <meta charset="utf-8" />
-    {{ .Hugo.Generator }}
+    {{ hugo.Generator }}
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link
       href="//fonts.googleapis.com/css?family=Open+Sans:400,800"


### PR DESCRIPTION
Hello!

Current version do not works with new hugo (broken since hugo version 0.53), patch fixes this problem.

I tried to follow guide https://www.sanity.io/guides/sanity-and-hugo-with-netlify-plugins but my hugo failed to build site from this repo:
~~~
xenon@mir:~/tmp/my-hugo-sanity-starter/web$ hugo serve
Start building sites … 
hugo v0.104.3-58b824581360148f2d91f5cc83f69bd22c1aa331+extended linux/amd64 BuildDate=2022-10-04T14:25:23Z VendorInfo=gohugoio
ERROR 2023/07/04 22:08:31 render of "page" failed: "/home/xenon/tmp/my-hugo-sanity-starter/web/layouts/_default/single.html:5:8": execute of template failed: template: _default/single.html:5:8: executing "_default/single.html" at <.Hugo.Generator>: can't evaluate field Hugo in type *hugolib.pageState
ERROR 2023/07/04 22:08:31 render of "taxonomy" failed: "/home/xenon/tmp/my-hugo-sanity-starter/web/layouts/_default/list.html:5:8": execute of template failed: template: _default/list.html:5:8: executing "_default/list.html" at <.Hugo.Generator>: can't evaluate field Hugo in type *hugolib.pageState
ERROR 2023/07/04 22:08:31 render of "home" failed: "/home/xenon/tmp/my-hugo-sanity-starter/web/layouts/_default/list.html:5:8": execute of template failed: template: _default/list.html:5:8: executing "_default/list.html" at <.Hugo.Generator>: can't evaluate field Hugo in type *hugolib.pageState
ERROR 2023/07/04 22:08:31 render of "taxonomy" failed: "/home/xenon/tmp/my-hugo-sanity-starter/web/layouts/_default/list.html:5:8": execute of template failed: template: _default/list.html:5:8: executing "_default/list.html" at <.Hugo.Generator>: can't evaluate field Hugo in type *hugolib.pageState
Error: Error building site: failed to render pages: render of "term" failed: "/home/xenon/tmp/my-hugo-sanity-starter/web/layouts/taxonomy/category.html:5:12": execute of template failed: template: taxonomy/category.html:5:12: executing "taxonomy/category.html" at <.Hugo.Generator>: can't evaluate field Hugo in type *hugolib.pageState
Built in 3 ms
~~~

I just changed every `{{ .Hugo.Generator }}` to `{{ hugo.Generator }}` and now it works.

Found solution here: https://discourse.gohugo.io/t/cant-evaluate-field-hugo-in-hugolib-pagestate/37862

With this patch `hugo server` works well.